### PR TITLE
🐛 Fixing regular expression of `[...]` used in European Portuguese Hunspell dictionary

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -132,7 +132,7 @@ function loadOtherWordsAndRebuildIndex(builtInWords: string[]) {
                     if (/\d+/.test(list[0])) {
                         list.splice(0, 1);
                     }
-                    list = list.map(word => word.replace(/\/.*$/, ''));
+                    list = list.map(word => word.replace(/[\/\[].*$/, ''));
 
                     userWordlists.push(list);
                 }


### PR DESCRIPTION
Hello @yzhang-gh 

It is ready! I tested and it worked. The `[...]` has been successfully removed from the autocompletion pop-up when searching a European Portuguese word. 