### PR TITLE
add support for quarto and Julia

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     },
     "activationEvents": [
         "onLanguage:markdown",
+        "onLanguage:quarto",
         "onLanguage:latex",
         "onLanguage:html",
         "onLanguage:javascript",
@@ -28,6 +29,7 @@
         "onLanguage:vue",
         "onLanguage:todo",
         "onLanguage:verilog",
+        "onLanguage:julia",
         "onLanguage:systemverilog"
     ],
     "main": "./out/src/extension",

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -69,6 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
             vscode.languages.registerCompletionItemProvider(getDocSelector('javascript'), new DictionaryCompletionItemProvider("javascript")),
             vscode.languages.registerCompletionItemProvider(getDocSelector('typescript'), new DictionaryCompletionItemProvider("typescript")),
             vscode.languages.registerCompletionItemProvider(getDocSelector('python'), new DictionaryCompletionItemProvider("python")),
+            vscode.languages.registerCompletionItemProvider(getDocSelector('julia'), new DictionaryCompletionItemProvider("julia")),
             vscode.languages.registerCompletionItemProvider([...getDocSelector('c'), ...getDocSelector('cpp')], new DictionaryCompletionItemProvider("c")),
             vscode.languages.registerCompletionItemProvider([...getDocSelector('verilog'), ...getDocSelector('systemverilog')], new DictionaryCompletionItemProvider("verilog"))
         );
@@ -247,7 +248,8 @@ class DictionaryCompletionItemProvider implements vscode.CompletionItemProvider 
                 if (/\[[^\]]*\]\([^\)]*$/.test(textBefore)) {
                     return [];
                 }
-                // ```{lang}``` -- code blocks
+                // ```{lang}``` -- code blocks TODO: not working, new to regexp
+                // this is also useful for markdown
                 if (/\`{3}{[\w\W]*[^\`]{3}$/.test(textBefore)) {
                     return [];
                 }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -248,7 +248,7 @@ class DictionaryCompletionItemProvider implements vscode.CompletionItemProvider 
                 if (/\[[^\]]*\]\([^\)]*$/.test(textBefore)) {
                     return [];
                 }
-                // ```{lang}``` -- code blocks TODO: not working, new to regexp
+                // ```{lang}``` -- code blocks
                 // this is also useful for markdown
                 if (/\`{3}{((?!\`{3})[\W\w])*$/.test(docTextBefore)) {
                     return [];
@@ -385,7 +385,7 @@ class DictionaryCompletionItemProvider implements vscode.CompletionItemProvider 
                     /\#{1,}/.test(tmpTextBeforeJulia) //// inline comment
                     || (
                         /(?<!\#)['"]/.test(tmpTextBeforeJulia) //// inline string
-                        && !/(import|require)/.test(tmpTextBeforeJulia.split(/['"]/)[0]) //// reject if in import/require clauses
+                        && !/(import|using|include)/.test(tmpTextBeforeJulia.split(/['"]/)[0]) //// reject if in import/require clauses
                     )
                 ) {
                     return this.completeByFirstLetter(firstLetter, addSpace);

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -250,7 +250,7 @@ class DictionaryCompletionItemProvider implements vscode.CompletionItemProvider 
                 }
                 // ```{lang}``` -- code blocks TODO: not working, new to regexp
                 // this is also useful for markdown
-                if (/\`{3}{[\w\W]*[^\`]{3}$/.test(textBefore)) {
+                if (/\`{3}{((?!\`{3})[\W\w])*$/.test(docTextBefore)) {
                     return [];
                 }
                 return this.completeByFirstLetter(firstLetter, addSpace);
@@ -382,7 +382,7 @@ class DictionaryCompletionItemProvider implements vscode.CompletionItemProvider 
                 //// Inline comment or string
                 const tmpTextBeforeJulia = textBefore.replace(/(?<!\#)('|").*?(?<!\#)\1/g, '');
                 if (
-                    /\/{2,}/.test(tmpTextBeforeJulia) //// inline comment
+                    /\#{1,}/.test(tmpTextBeforeJulia) //// inline comment
                     || (
                         /(?<!\#)['"]/.test(tmpTextBeforeJulia) //// inline string
                         && !/(import|require)/.test(tmpTextBeforeJulia.split(/['"]/)[0]) //// reject if in import/require clauses


### PR DESCRIPTION
This PR adds support for Quarto and Julia
Quarto is similar to Rmarkdown but can run multiple languages [quarto](https://quarto.org/)

But one problem for now is to exclude code blocks. My regexp is not working as expected, help needed.
